### PR TITLE
Delete unnecessary glib-2.0 dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL Windows)
 
 message(STATUS "CMake generates " ${CMAKE_GENERATOR})
 
-include_directories(${SC_MEMORY_SRC} ${GLIB2_INCLUDE_DIRS}${SC_MACHINE_ROOT})
+include_directories(${SC_MEMORY_SRC} ${SC_MACHINE_ROOT})
 add_executable(wave wavefindpath.cpp utils.cpp utils.h)
 
 
-target_link_libraries(wave sc-core sc-memory ${GLIB2_LIBRARIES})
+target_link_libraries(wave sc-core sc-memory)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,25 +15,6 @@ link_directories(${SC_MACHINE_ROOT}/bin)
 
 set(SC_MEMORY_SRC "${SC_MACHINE_ROOT}/sc-memory/")
 
-# find dependencies
-if (${UNIX})
-	include(FindPkgConfig)
-	pkg_check_modules (GLIB2 REQUIRED glib-2.0)
-	pkg_check_modules (GLIB2_MODULE REQUIRED gmodule-2.0)
-
-	set (GLIB2_INCLUDE_DIRS "${GLIB2_INCLUDE_DIRS}" "/usr/lib/x86_64-linux-gnu/glib-2.0/include/" "${GLIB2_MODULE}")
-	set (GLIB2_LIBRARIES "${GLIB2_LIBRARIES}" "${GLIB2_MODULE_LIBRARIES}")
-
-endif(${UNIX})
-
-if (${APPLE})
-    find_package(PkgConfig REQUIRED)
-    pkg_search_module(GLIB2 REQUIRED glib-2.0)
-    pkg_search_module(GLIB2_MODULE REQUIRED gmodule-2.0)
-
-    set (GLIB2_LIBRARIES ${GLIB_LDFLAGS} ${GLIB2_MODULE_LDFLAGS})
-endif(${APPLE})
-
 if (${CMAKE_SYSTEM_NAME} STREQUAL Windows)
 	if(MSVC)
 		message(STATUS "Compiler: MSVC, version: " ${MSVC_VERSION})


### PR DESCRIPTION
While updating documentation for `ostis-apps/dockerized-ostis` I've realized that we have an orphan dependency in this project - glib-2.0. It is actually not used anywhere in the example, so the code builds and runs just fine without this library.